### PR TITLE
remove debug log in github actions

### DIFF
--- a/.github/workflows/pullrequest-ci.yaml
+++ b/.github/workflows/pullrequest-ci.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Build standard library
         run: go install std
         env:
-          GOCACHEPROG: "./${{ env.APP_NAME }} -r ${{ matrix.remote }} -l debug"
+          GOCACHEPROG: "./${{ env.APP_NAME }} -r ${{ matrix.remote }}"
           GOCICA_S3_BUCKET: ${{ secrets.GOCICA_S3_BUCKET }}
           GOCICA_S3_REGION: ${{ secrets.GOCICA_S3_REGION }}
           GOCICA_S3_ACCESS_KEY: ${{ secrets.GOCICA_S3_ACCESS_KEY }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/pullrequest-ci.yaml` file. The change involves modifying the `GOCACHEPROG` environment variable by removing the `-l debug` flag from the command.

* [`.github/workflows/pullrequest-ci.yaml`](diffhunk://#diff-1a4780cb3787799e362b101f62b6658ad15998550cf30712a97dc22bfe7ff16fL61-R61): Removed the `-l debug` flag from the `GOCACHEPROG` environment variable in the `Build standard library` job.