### PR TITLE
Fix commit cache entry error

### DIFF
--- a/.github/workflows/pullrequest-ci.yaml
+++ b/.github/workflows/pullrequest-ci.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Build standard library
         run: go install std
         env:
-          GOCACHEPROG: "./${{ env.APP_NAME }} -r ${{ matrix.remote }} -l debug"
+          GOCACHEPROG: "./${{ env.APP_NAME }} -r ${{ matrix.remote }}"
           GOCICA_S3_BUCKET: ${{ secrets.GOCICA_S3_BUCKET }}
           GOCICA_S3_REGION: ${{ secrets.GOCICA_S3_REGION }}
           GOCICA_S3_ACCESS_KEY: ${{ secrets.GOCICA_S3_ACCESS_KEY }}

--- a/internal/backend/blob/upload.go
+++ b/internal/backend/blob/upload.go
@@ -50,7 +50,7 @@ func NewUploader(ctx context.Context, logger log.Logger, client UploadClient, ba
 	return uploader
 }
 
-func (u *Uploader) getenarteBlockID() (string, error) {
+func (u *Uploader) generateBlockID() (string, error) {
 	var buf [32]byte
 	if _, err := rand.Read(buf[:]); err != nil {
 		return "", fmt.Errorf("read random: %w", err)
@@ -73,7 +73,7 @@ func (u *Uploader) setupBase(ctx context.Context, baseBlobProvider BaseBlobProvi
 	)
 	eg.Go(func() error {
 		var err error
-		baseBlockID, err = u.getenarteBlockID()
+		baseBlockID, err = u.generateBlockID()
 		if err != nil {
 			return fmt.Errorf("generate block ID: %w", err)
 		}
@@ -188,7 +188,7 @@ func (u *Uploader) Commit(ctx context.Context, entries map[string]*v1.IndexEntry
 		return 0, fmt.Errorf("create header: %w", err)
 	}
 
-	headerBlockID, err := u.getenarteBlockID()
+	headerBlockID, err := u.generateBlockID()
 	if err != nil {
 		return 0, fmt.Errorf("generate header block ID: %w", err)
 	}

--- a/internal/backend/blob/upload.go
+++ b/internal/backend/blob/upload.go
@@ -157,10 +157,11 @@ func (u *Uploader) constructOutputs(baseOutputSize int64, baseOutputs map[string
 	return newOutputIDs, outputs, offset
 }
 
-func (u *Uploader) createHeader(entries map[string]*v1.IndexEntry, outputs map[string]*v1.ActionsOutput) ([]byte, error) {
+func (u *Uploader) createHeader(entries map[string]*v1.IndexEntry, outputs map[string]*v1.ActionsOutput, outputSize int64) ([]byte, error) {
 	actionsCache := &v1.ActionsCache{
-		Entries: entries,
-		Outputs: outputs,
+		Entries:         entries,
+		Outputs:         outputs,
+		OutputTotalSize: outputSize,
 	}
 
 	protobufBuf, err := proto.Marshal(actionsCache)
@@ -183,7 +184,7 @@ func (u *Uploader) Commit(ctx context.Context, entries map[string]*v1.IndexEntry
 
 	newOutputIDs, outputs, outputSize := u.constructOutputs(baseOutputSize, baseOutputs)
 
-	headerBuf, err := u.createHeader(entries, outputs)
+	headerBuf, err := u.createHeader(entries, outputs, outputSize)
 	if err != nil {
 		return 0, fmt.Errorf("create header: %w", err)
 	}

--- a/internal/backend/blob/upload_test.go
+++ b/internal/backend/blob/upload_test.go
@@ -492,6 +492,7 @@ func TestUploader_createHeader(t *testing.T) {
 		name           string
 		entries        map[string]*v1.IndexEntry
 		outputs        map[string]*v1.ActionsOutput
+		outputSize     int64
 		expectError    bool
 		validateHeader func(*testing.T, []byte)
 	}{
@@ -511,6 +512,7 @@ func TestUploader_createHeader(t *testing.T) {
 					Size:   100,
 				},
 			},
+			outputSize: 100,
 			validateHeader: func(t *testing.T, headerBytes []byte) {
 				if len(headerBytes) <= 8 {
 					t.Error("header is too short")
@@ -539,6 +541,9 @@ func TestUploader_createHeader(t *testing.T) {
 				if diff := cmp.Diff(int64(100), header.Outputs["test"].Size); diff != "" {
 					t.Errorf("output Size mismatch (-want +got):\n%s", diff)
 				}
+				if diff := cmp.Diff(int64(100), header.OutputTotalSize); diff != "" {
+					t.Errorf("output total size mismatch (-want +got):\n%s", diff)
+				}
 			},
 		},
 	}
@@ -550,7 +555,7 @@ func TestUploader_createHeader(t *testing.T) {
 
 			uploader := &Uploader{}
 
-			header, err := uploader.createHeader(tt.entries, tt.outputs)
+			header, err := uploader.createHeader(tt.entries, tt.outputs, tt.outputSize)
 			if tt.expectError {
 				if err == nil {
 					t.Error("expected error, got nil")


### PR DESCRIPTION
This pull request includes several changes to the `internal/backend/blob/upload.go` file and related test files, as well as a minor update to the GitHub Actions workflow configuration. The most important changes include renaming a method, updating method signatures, and modifying tests to accommodate these changes.

Changes to method names and signatures:

* [`internal/backend/blob/upload.go`](diffhunk://#diff-9b39d800557a8b4c80ea09d56c1d612e295da636b6f0b2b90bdd61ecb9117decL53-R53): Renamed the method `getenarteBlockID` to `generateBlockID` to correct the spelling and updated all references to this method accordingly. [[1]](diffhunk://#diff-9b39d800557a8b4c80ea09d56c1d612e295da636b6f0b2b90bdd61ecb9117decL53-R53) [[2]](diffhunk://#diff-9b39d800557a8b4c80ea09d56c1d612e295da636b6f0b2b90bdd61ecb9117decL76-R76) [[3]](diffhunk://#diff-9b39d800557a8b4c80ea09d56c1d612e295da636b6f0b2b90bdd61ecb9117decL186-R192)
* [`internal/backend/blob/upload.go`](diffhunk://#diff-9b39d800557a8b4c80ea09d56c1d612e295da636b6f0b2b90bdd61ecb9117decL160-R164): Updated the `createHeader` method to include an additional `outputSize` parameter, and modified all calls to this method to pass the new parameter. [[1]](diffhunk://#diff-9b39d800557a8b4c80ea09d56c1d612e295da636b6f0b2b90bdd61ecb9117decL160-R164) [[2]](diffhunk://#diff-9b39d800557a8b4c80ea09d56c1d612e295da636b6f0b2b90bdd61ecb9117decL186-R192)

Updates to tests:

* [`internal/backend/blob/upload_test.go`](diffhunk://#diff-47f6ab2272e7c5c000bb118f7a28d6a10bfcb3c2f3738abbf5c36d6e2f4b898cR495): Added the `outputSize` parameter to the `TestUploader_createHeader` test cases and updated the validation logic to check for the new `OutputTotalSize` field in the header. [[1]](diffhunk://#diff-47f6ab2272e7c5c000bb118f7a28d6a10bfcb3c2f3738abbf5c36d6e2f4b898cR495) [[2]](diffhunk://#diff-47f6ab2272e7c5c000bb118f7a28d6a10bfcb3c2f3738abbf5c36d6e2f4b898cR515) [[3]](diffhunk://#diff-47f6ab2272e7c5c000bb118f7a28d6a10bfcb3c2f3738abbf5c36d6e2f4b898cR544-R546) [[4]](diffhunk://#diff-47f6ab2272e7c5c000bb118f7a28d6a10bfcb3c2f3738abbf5c36d6e2f4b898cL553-R558)

Minor workflow update:

* [`.github/workflows/pullrequest-ci.yaml`](diffhunk://#diff-1a4780cb3787799e362b101f62b6658ad15998550cf30712a97dc22bfe7ff16fL61-R61): Removed the `-l debug` flag from the `GOCACHEPROG` environment variable in the GitHub Actions workflow configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
  - Streamlined the build configuration for cleaner, less verbose logs.
- **Refactor**
  - Optimized the upload processing to ensure accurate handling of data sizes.
- **Tests**
  - Expanded test coverage to validate improved data tracking during uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->