### PR TITLE
fix goreleaser setting

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,7 @@ builds:
     main: ./
 
 archives:
-  - format: tar.gz
+  - format: binary
     # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
       {{ .ProjectName }}_
@@ -27,12 +27,14 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
-    format_overrides:
-    - goos: windows
-      format: zip
 checksum:
   name_template: 'checksums.txt'
+release:
+  extra_files:
+    - name_template: LICENSE
+      glob: LICENSE
+    - name_template: README.md
+      glob: README.md
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:


### PR DESCRIPTION
This pull request includes changes to the `.goreleaser.yaml` file to modify the build and archive formats, as well as adding extra files to the release. The most important changes include switching the archive format from `tar.gz` to `binary`, removing format overrides for Windows archives, and including additional files in the release.

Changes to build and archive formats:

* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L21-R21): Changed the archive format from `tar.gz` to `binary`.
* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L30-R37): Removed format overrides that used `zip` for Windows archives.

Additional files in release:

* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L30-R37): Added `LICENSE` and `README.md` to the extra files section of the release configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Essential documentation is now automatically bundled with each release to provide users with necessary license and usage information.
- **Chores**
  - Updated the artifact packaging format to streamline the distribution process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->