### PR TITLE
Execute the time command during benchmarking

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           go-version: 1.24.1
       - uses: gocica-go/gocica-action@v0.1.0-alpha1
-      - run: go install std
+      - run: time go install std
   cache_gocica_github:
     name: GoCICa GitHub(Cache)
     runs-on: ubuntu-latest
@@ -52,7 +52,7 @@ jobs:
         with:
           go-version: 1.24.1
       - uses: gocica-go/gocica-action@v0.1.0-alpha1
-      - run: go install std
+      - run: time go install std
   no_cache_gocica_s3:
     name: GoCICa S3(No Cache)
     runs-on: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
         with:
           go-version: 1.24.1
       - uses: gocica-go/gocica-action@v0.1.0-alpha1
-      - run: go install std
+      - run: time go install std
   cache_gocica_s3:
     name: GoCICa S3(Cache)
     runs-on: ubuntu-latest
@@ -91,7 +91,7 @@ jobs:
           s3-region: ${{ secrets.GOCICA_S3_REGION }}
           s3-access-key: ${{ secrets.GOCICA_S3_ACCESS_KEY }}
           s3-secret-access-key: ${{ secrets.GOCICA_S3_SECRET_ACCESS_KEY }}
-      - run: go install std
+      - run: time go install std
   no_cache_default:
     name: action/cache(No Cache)
     runs-on: ubuntu-latest
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
-      - run: go install std
+      - run: time go install std
   cache_default:
     name: action/cache(Cache)
     runs-on: ubuntu-latest
@@ -153,4 +153,4 @@ jobs:
           restore-keys: |
             go-build-${{ runner.os }}-${{ github.ref }}-
             go-build-${{ runner.os }}-
-      - run: go install std
+      - run: time go install std


### PR DESCRIPTION
This pull request makes several updates to the `.github/workflows/benchmark.yaml` file to include timing information for the `go install std` command in various job steps. This change is aimed at measuring the duration of the `go install std` command across different caching scenarios.

Changes to benchmark workflow:

* [`.github/workflows/benchmark.yaml`](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L41-R41): Updated the `run` command from `go install std` to `time go install std` in multiple job steps to measure the execution time of the `go install std` command. [[1]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L41-R41) [[2]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L55-R55) [[3]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L74-R74) [[4]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L94-R94) [[5]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L134-R134) [[6]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L156-R156)