### PR TITLE
fix actions/cache cache purge

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -158,6 +158,9 @@ jobs:
               })
             }
             console.log("Clear completed")
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.1
       - uses: actions/cache@v4
         with:
           path: /tmp/go/cache
@@ -165,9 +168,6 @@ jobs:
           restore-keys: |
             go-build-${{ runner.os }}-${{ github.ref }}-
             go-build-${{ runner.os }}-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: 1.24.1
       - run: go mod download
       - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
         env:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/benchmark.yaml` file. The change reorders the `actions/setup-go@v5` step to run before the `actions/cache@v4` step for setting up the Go environment.

* [`.github/workflows/benchmark.yaml`](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R161-L170): Moved the `actions/setup-go@v5` step to run before the `actions/cache@v4` step to ensure Go is set up before caching dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Made internal adjustments to the automation workflow sequence to ensure optimal task ordering. These changes are purely behind-the-scenes and do not affect any end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->