### PR TITLE
Disable cache for setup-go

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -7,13 +7,41 @@ permissions:
   actions: write
 
 jobs:
+  setup_modcache:
+    name: Setup modcache
+    runs-on: ubuntu-latest
+    env:
+      GOMODCACHE: /tmp/gocache/mod
+      GOCACHE: /tmp/gocache/build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: traPtitech/traQ
+          ref: v3.22.0
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.1
+          cache: false # Disable cache for redundant cache clearing
+      - uses: actions/cache@v4 # Go mod cache(not covered by Go setup cache)
+        with:
+          path: ${{ env.GOMODCACHE }}
+          key: go-mod-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-${{ github.ref }}-
+            go-mod-${{ runner.os }}-
+      - run: go mod download
   no_cache_gocica_github:
     name: GoCICa GitHub(No Cache)
     runs-on: ubuntu-latest
+    needs: [setup_modcache]
     strategy:
       matrix:
         id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
       max-parallel: 1
+    env:
+      GOMODCACHE: /tmp/gocache/mod
+      GOCACHE: /tmp/gocache/build
     steps:
       - name: Clear cache
         uses: actions/github-script@v6
@@ -42,6 +70,14 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
+          cache: false # Disable cache for redundant cache clearing
+      - uses: actions/cache@v4 # Go mod cache(not covered by Go setup cache)
+        with:
+          path: ${{ env.GOMODCACHE }}
+          key: go-mod-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-${{ github.ref }}-
+            go-mod-${{ runner.os }}-
       - uses: gocica-go/gocica-action@v0.1.0-alpha1
       - run: go mod download
       - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
@@ -50,11 +86,14 @@ jobs:
   cache_gocica_github:
     name: GoCICa GitHub(Cache)
     runs-on: ubuntu-latest
-    needs: [no_cache_gocica_github]
+    needs: [no_cache_gocica_github, setup_modcache]
     strategy:
       matrix:
         id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
       max-parallel: 1
+    env:
+      GOMODCACHE: /tmp/gocache/mod
+      GOCACHE: /tmp/gocache/build
     steps:
       - uses: actions/checkout@v4
         with:
@@ -64,6 +103,14 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
+          cache: false # Disable cache for redundant cache clearing
+      - uses: actions/cache@v4 # Go mod cache(not covered by Go setup cache)
+        with:
+          path: ${{ env.GOMODCACHE }}
+          key: go-mod-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-${{ github.ref }}-
+            go-mod-${{ runner.os }}-
       - uses: gocica-go/gocica-action@v0.1.0-alpha1
       - run: go mod download
       - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
@@ -72,10 +119,14 @@ jobs:
   no_cache_gocica_s3:
     name: GoCICa S3(No Cache)
     runs-on: ubuntu-latest
+    needs: [setup_modcache]
     strategy:
       matrix:
         id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
       max-parallel: 1
+    env:
+      GOMODCACHE: /tmp/gocache/mod
+      GOCACHE: /tmp/gocache/build
     steps:
       - name: Clear cache
         run: aws s3 rm --recursive s3://${{ secrets.GOCICA_S3_BUCKET }}
@@ -91,6 +142,14 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
+          cache: false # Disable cache for redundant cache clearing
+      - uses: actions/cache@v4 # Go mod cache(not covered by Go setup cache)
+        with:
+          path: ${{ env.GOMODCACHE }}
+          key: go-mod-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-${{ github.ref }}-
+            go-mod-${{ runner.os }}-
       - uses: gocica-go/gocica-action@v0.1.0-alpha1
       - run: go mod download
       - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
@@ -99,11 +158,14 @@ jobs:
   cache_gocica_s3:
     name: GoCICa S3(Cache)
     runs-on: ubuntu-latest
-    needs: [no_cache_gocica_s3]
+    needs: [no_cache_gocica_s3, setup_modcache]
     strategy:
       matrix:
         id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
       max-parallel: 1
+    env:
+      GOMODCACHE: /tmp/gocache/mod
+      GOCACHE: /tmp/gocache/build
     steps:
       - uses: actions/checkout@v4
         with:
@@ -113,6 +175,14 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
+          cache: false # Disable cache for redundant cache clearing
+      - uses: actions/cache@v4 # Go mod cache(not covered by Go setup cache)
+        with:
+          path: ${{ env.GOMODCACHE }}
+          key: go-mod-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-${{ github.ref }}-
+            go-mod-${{ runner.os }}-
       - uses: gocica-go/gocica-action@v0.1.0-alpha1
         with:
           remote: s3
@@ -127,10 +197,14 @@ jobs:
   no_cache_default:
     name: action/cache(No Cache)
     runs-on: ubuntu-latest
+    needs: [setup_modcache]
     strategy:
       matrix:
         id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
       max-parallel: 1
+    env:
+      GOMODCACHE: /tmp/gocache/mod
+      GOCACHE: /tmp/gocache/build
     steps:
       - uses: actions/checkout@v4
         with:
@@ -159,6 +233,21 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
+          cache: false # Disable cache for redundant cache clearing
+      - uses: actions/cache@v4 # Go mod cache(not covered by Go setup cache)
+        with:
+          path: ${{ env.GOMODCACHE }}
+          key: go-mod-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-${{ github.ref }}-
+            go-mod-${{ runner.os }}-
+      - uses: actions/cache@v4 # Go build cache
+        with:
+          path: ${{ env.GOCACHE }}
+          key: go-build-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ github.ref }}-
+            go-build-${{ runner.os }}-
       - run: go mod download
       - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
         env:
@@ -166,11 +255,14 @@ jobs:
   cache_default:
     name: action/cache(Cache)
     runs-on: ubuntu-latest
-    needs: [no_cache_default]
+    needs: [no_cache_default, setup_modcache]
     strategy:
       matrix:
         id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
       max-parallel: 1
+    env:
+      GOMODCACHE: /tmp/gocache/mod
+      GOCACHE: /tmp/gocache/build
     steps:
       - uses: actions/checkout@v4
         with:
@@ -180,6 +272,21 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
+          cache: false # Disable cache for redundant cache clearing
+      - uses: actions/cache@v4 # Go mod cache(not covered by Go setup cache)
+        with:
+          path: ${{ env.GOMODCACHE }}
+          key: go-mod-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            go-mod-${{ runner.os }}-${{ github.ref }}-
+            go-mod-${{ runner.os }}-
+      - uses: actions/cache@v4 # Go build cache
+        with:
+          path: ${{ env.GOCACHE }}
+          key: go-build-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            go-build-${{ runner.os }}-${{ github.ref }}-
+            go-build-${{ runner.os }}-
       - run: go mod download
       - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
         env:


### PR DESCRIPTION
The download/upload of the setup-go cache was also occurring when GoCICa was used, and the appropriate GoCICa and actions/cache were not being compared.
Therefore, we aligned the conditions by disabling setup-go's cache and re-implementing only Go Module Cache on our own.
If this benchmark is confirmed to be valid, we will add an implementation of Go Module Cache to gocica-action, so that only gocica-action can supplement setup-go's cache function.

### Improvements to caching strategy:

* **Setup modcache job**: Added a new job `setup_modcache` to set up the Go module cache. This job runs on `ubuntu-latest` and sets environment variables for `GOMODCACHE` and `GOCACHE`. It includes steps for checking out the repository, setting up Go, and caching the Go module.

* **Integration of setup_modcache**: Updated existing jobs (`no_cache_gocica_github`, `cache_gocica_github`, `no_cache_gocica_s3`, `cache_gocica_s3`, `no_cache_default`, `cache_default`) to depend on the `setup_modcache` job and use the environment variables `GOMODCACHE` and `GOCACHE` for caching. [[1]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L53-R96) [[2]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R122-R129) [[3]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L102-R168) [[4]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R200-R207) [[5]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R236-R265) [[6]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R275-R289)

* **Disable redundant cache clearing**: Added `cache: false` in the `actions/setup-go@v5` step to disable redundant cache clearing across multiple jobs. [[1]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R73-R80) [[2]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R106-R113) [[3]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R145-R152) [[4]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R178-R185) [[5]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R236-R265) [[6]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R275-R289)

* **Go build cache**: Added steps to cache the Go build cache using `actions/cache@v4` in the `no_cache_default` and `cache_default` jobs. This includes setting the cache path to `GOCACHE` and defining cache keys and restore keys. [[1]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R236-R265) [[2]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R275-R289)