### PR TITLE
fix actions/cache cache purge

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -219,7 +219,7 @@ jobs:
             const caches = await github.rest.actions.getActionsCacheList({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              key: "setup-go-"
+              key: "go-build-"
             })
             for (const cache of caches.data.actions_caches) {
               console.log(cache)


### PR DESCRIPTION
This pull request includes a change to the caching key used in the GitHub Actions workflow for benchmarking. The change updates the key to better reflect the cache's purpose.

* [`.github/workflows/benchmark.yaml`](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L222-R222): Changed the cache key from `"setup-go-"` to `"go-build-"` in the `jobs:` section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted the caching configuration in our automation processes to ensure smoother, more reliable operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->