### PR TITLE
Fix dummy metrics

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0 h1:UXT0o77lXQrikd1kg
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0/go.mod h1:cTvi54pg19DoT07ekoeMgE/taAwNtCShVeZqA+Iv2xI=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.3.2 h1:kYRSnvJju5gYVyhkij+RTJ/VR6QIUaCfWeaFm2ycsjQ=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.3.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
-github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
-github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/kong v1.8.1 h1:6aamvWBE/REnR/BCq10EcozmcpUPc5aGI1lPAWdB0EE=
@@ -40,6 +38,8 @@ github.com/felixge/fgprof v0.9.5/go.mod h1:yKl+ERSa++RYOs32d8K6WEXCB4uXdLls4ZaZP
 github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
+github.com/gocica-go/zstd v1.5.6 h1:JHuFD2ed/Gg+kXfGve0wKN96xjTGthA3n6D/mLdICfo=
+github.com/gocica-go/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/internal/backend/blob/azure_blob_storage.go
+++ b/internal/backend/blob/azure_blob_storage.go
@@ -31,7 +31,7 @@ func (a *AzureUploadClient) UploadBlock(ctx context.Context, blockID string, r i
 		return 0, fmt.Errorf("seek start: %w", err)
 	}
 
-	latencyGauge.Stapwatch(func() {
+	latencyGauge.Stopwatch(func() {
 		_, err = a.client.StageBlock(ctx, blockID, r, nil)
 	}, "stage_block")
 	if err != nil {
@@ -43,7 +43,7 @@ func (a *AzureUploadClient) UploadBlock(ctx context.Context, blockID string, r i
 
 func (a *AzureUploadClient) UploadBlockFromURL(ctx context.Context, blockID string, url string, offset, size int64) error {
 	var err error
-	latencyGauge.Stapwatch(func() {
+	latencyGauge.Stopwatch(func() {
 		_, err = a.client.StageBlockFromURL(ctx, blockID, url, &blockblob.StageBlockFromURLOptions{
 			Range: blob.HTTPRange{Offset: offset, Count: size},
 		})
@@ -57,7 +57,7 @@ func (a *AzureUploadClient) UploadBlockFromURL(ctx context.Context, blockID stri
 
 func (a *AzureUploadClient) Commit(ctx context.Context, blockIDs []string) error {
 	var err error
-	latencyGauge.Stapwatch(func() {
+	latencyGauge.Stopwatch(func() {
 		_, err = a.client.CommitBlockList(ctx, blockIDs, nil)
 	}, "commit_block_list")
 	if err != nil {
@@ -86,7 +86,7 @@ func (a *AzureDownloadClient) DownloadBlock(ctx context.Context, offset int64, s
 		res blob.DownloadStreamResponse
 		err error
 	)
-	latencyGauge.Stapwatch(func() {
+	latencyGauge.Stopwatch(func() {
 		res, err = a.client.DownloadStream(ctx, &blob.DownloadStreamOptions{
 			Range: blob.HTTPRange{Offset: offset, Count: size},
 		})
@@ -105,7 +105,7 @@ func (a *AzureDownloadClient) DownloadBlock(ctx context.Context, offset int64, s
 
 func (a *AzureDownloadClient) DownloadBlockBuffer(ctx context.Context, offset int64, size int64, buf []byte) error {
 	var err error
-	latencyGauge.Stapwatch(func() {
+	latencyGauge.Stopwatch(func() {
 		_, err = a.client.DownloadBuffer(ctx, buf, &blob.DownloadBufferOptions{
 			Range: blob.HTTPRange{Offset: offset, Count: size},
 		})

--- a/internal/backend/blob/upload.go
+++ b/internal/backend/blob/upload.go
@@ -126,7 +126,7 @@ func (u *Uploader) UploadOutput(ctx context.Context, outputID string, size int64
 		zw := zstd.NewWriterLevel(buf, 1)
 
 		var err error
-		compressGauge.Stapwatch(func() {
+		compressGauge.Stopwatch(func() {
 			_, err = io.Copy(zw, r)
 		}, "compress_data")
 		if err != nil {

--- a/internal/backend/github_actions_cache.go
+++ b/internal/backend/github_actions_cache.go
@@ -175,7 +175,7 @@ func (c *GitHubActionsCache) doRequest(ctx context.Context, endpoint string, req
 	req.Header.Set("Content-Type", "application/json")
 
 	var res *http.Response
-	latencyGauge.Stapwatch(func() {
+	latencyGauge.Stopwatch(func() {
 		res, err = c.githubClient.Do(req)
 	}, endpoint)
 	if err != nil {

--- a/internal/metrics/dummy_dev_metrics.go
+++ b/internal/metrics/dummy_dev_metrics.go
@@ -16,6 +16,6 @@ type Gauge struct{}
 
 func (g *Gauge) Set(float64, string) {}
 
-func (g *Gauge) Stapwatch(f func(), lebel string) {
+func (g *Gauge) Stapwatch(f func(), _ string) {
 	f()
 }

--- a/internal/metrics/dummy_dev_metrics.go
+++ b/internal/metrics/dummy_dev_metrics.go
@@ -16,4 +16,6 @@ type Gauge struct{}
 
 func (g *Gauge) Set(float64, string) {}
 
-func (g *Gauge) Stapwatch(func(), string) {}
+func (g *Gauge) Stapwatch(f func(), lebel string) {
+	f()
+}

--- a/internal/metrics/dummy_dev_metrics.go
+++ b/internal/metrics/dummy_dev_metrics.go
@@ -16,6 +16,6 @@ type Gauge struct{}
 
 func (g *Gauge) Set(float64, string) {}
 
-func (g *Gauge) Stapwatch(f func(), _ string) {
+func (g *Gauge) Stopwatch(f func(), _ string) {
 	f()
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -86,7 +86,7 @@ func (g *Gauge) getRecords() []record {
 	return g.records
 }
 
-func (g *Gauge) Stapwatch(f func(), label string) {
+func (g *Gauge) Stopwatch(f func(), label string) {
 	start := time.Now()
 	start = start.Round(0) // delete monotonic clock value
 	f()


### PR DESCRIPTION
This pull request includes a change to the `internal/metrics/dummy_dev_metrics.go` file to correct a typo and ensure the function executes as intended.

* [`internal/metrics/dummy_dev_metrics.go`](diffhunk://#diff-486aff9893f8ec62b0b9a2a47960099ef1f349ab8d791c602eb02cd54e1769e1L19-R21): Modified the `Stapwatch` method in the `Gauge` struct to correct the parameter name from "lebel" to "label" and ensure the passed function is executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved operation tracking to ensure that delegated tasks now execute as expected.
	- Corrected a minor labeling inconsistency to enhance overall clarity.
	- Updated method references for tracking execution duration to ensure consistency across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->