### PR TITLE
Update benchmark actions version

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -78,7 +78,7 @@ jobs:
           restore-keys: |
             go-mod-${{ runner.os }}-${{ github.ref }}-
             go-mod-${{ runner.os }}-
-      - uses: gocica-go/gocica-action@v0.1.0-alpha1
+      - uses: gocica-go/gocica-action@v0.1.0-alpha2
       - run: go mod download
       - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
         env:
@@ -111,7 +111,7 @@ jobs:
           restore-keys: |
             go-mod-${{ runner.os }}-${{ github.ref }}-
             go-mod-${{ runner.os }}-
-      - uses: gocica-go/gocica-action@v0.1.0-alpha1
+      - uses: gocica-go/gocica-action@v0.1.0-alpha2
       - run: go mod download
       - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
         env:


### PR DESCRIPTION
This pull request includes a small update to the `.github/workflows/benchmark.yaml` file, specifically updating the version of the `gocica-go/gocica-action` used in the workflow.

* [`.github/workflows/benchmark.yaml`](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L81-R81): Updated `gocica-go/gocica-action` from `v0.1.0-alpha1` to `v0.1.0-alpha2` in two places. [[1]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L81-R81) [[2]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L114-R114)