### PR TITLE
Close in the middle of JoinedWriter

### DIFF
--- a/internal/backend/blob/download.go
+++ b/internal/backend/blob/download.go
@@ -147,9 +147,11 @@ func (d *Downloader) DownloadAllOutputBlocks(ctx context.Context, objectWriterFu
 		eg.Go(func() error {
 			defer s.Release(int64(len(chunkWriters)))
 			defer func() {
+				// io.WriteCloser is expected to be already Closed in JoindWriter.
+				// However, in order to avoid deadlock in the event that an error occurs during the process and Close is not performed, Close is performed by defer without fail.
 				for _, closeFunc := range chunkCloseFuncs {
 					if err := closeFunc(); err != nil {
-						d.logger.Errorf("close object writer: %v", err)
+						d.logger.Debugf("close object writer: %v", err)
 					}
 				}
 			}()

--- a/internal/backend/disk.go
+++ b/internal/backend/disk.go
@@ -100,11 +100,11 @@ func (d *Disk) Put(_ context.Context, outputID string, _ int64) (string, io.Writ
 	d.logger.Debugf("write lock acquired outputID=%s", outputID)
 	wrapped := &WriteCloserWithUnlock{
 		WriteCloser: f,
-		unlock: sync.OnceFunc(func() {
+		unlock: func() {
 			d.logger.Debugf("lock released outputID=%s", outputID)
 			l.ok = true
 			l.l.Unlock()
-		}),
+		},
 	}
 
 	return outputFilePath, wrapped, nil

--- a/internal/backend/disk.go
+++ b/internal/backend/disk.go
@@ -100,11 +100,11 @@ func (d *Disk) Put(_ context.Context, outputID string, _ int64) (string, io.Writ
 	d.logger.Debugf("write lock acquired outputID=%s", outputID)
 	wrapped := &WriteCloserWithUnlock{
 		WriteCloser: f,
-		unlock: func() {
+		unlock: sync.OnceFunc(func() {
 			d.logger.Debugf("lock released outputID=%s", outputID)
 			l.ok = true
 			l.l.Unlock()
-		},
+		}),
 	}
 
 	return outputFilePath, wrapped, nil

--- a/internal/pkg/io/joined_writer.go
+++ b/internal/pkg/io/joined_writer.go
@@ -3,7 +3,7 @@ package io
 import "io"
 
 type WriterWithSize struct {
-	Writer io.Writer
+	Writer io.WriteCloser // Changed from io.Writer to io.WriteCloser
 	Size   int64
 }
 
@@ -30,6 +30,10 @@ func (j *JoinedWriter) Write(p []byte) (n int, err error) {
 	for j.curWriter < len(j.writers) {
 		writer := &j.writers[j.curWriter]
 		if writer.Size <= 0 {
+			// Close writers with size <= 0 and move to the next writer
+			if closeErr := writer.Writer.Close(); closeErr != nil {
+				return totalWritten, closeErr
+			}
 			j.curWriter++
 			continue
 		}


### PR DESCRIPTION
Close the Writer that has finished writing in the middle of JoinedWriter.
This will release the lock early and speed up the cache reply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved resource management that automatically closes streams when they're no longer needed, enhancing stability and performance.
  
- **Bug Fixes**
  - Adjusted error logging during resource closure to report issues at a lower severity, ensuring more informative debugging without impacting normal operations.

- **Tests**
  - Updated testing procedures to validate the new resource handling and closure behaviors, ensuring consistent reliability under various conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->