### PR TITLE
upload existing outputs in parallel

### DIFF
--- a/internal/backend/blob/upload.go
+++ b/internal/backend/blob/upload.go
@@ -86,14 +86,15 @@ func (u *Uploader) setupBase(ctx context.Context, baseBlobProvider BaseBlobProvi
 
 		var uploadSize int64
 		for i := int64(0); i < size; i += uploadSize {
-			eg.Go(func() error {
-				baseBlockID, err := u.generateBlockID()
-				if err != nil {
-					return fmt.Errorf("generate block ID: %w", err)
-				}
+			baseBlockID, err := u.generateBlockID()
+			if err != nil {
+				return fmt.Errorf("generate block ID: %w", err)
+			}
 
-				uploadSize = min(maxUploadChunkSize, size-i)
-				err = u.client.UploadBlockFromURL(ctx, baseBlockID, url, offset+i, uploadSize)
+			chunkUploadSize := min(maxUploadChunkSize, size-i)
+			uploadSize = chunkUploadSize
+			eg.Go(func() error {
+				err = u.client.UploadBlockFromURL(ctx, baseBlockID, url, offset+i, chunkUploadSize)
 				if err != nil {
 					return fmt.Errorf("upload block from URL: %w", err)
 				}

--- a/internal/backend/blob/upload.go
+++ b/internal/backend/blob/upload.go
@@ -73,8 +73,9 @@ func (u *Uploader) setupBase(ctx context.Context, baseBlobProvider BaseBlobProvi
 	eg, ctx := errgroup.WithContext(ctx)
 
 	var (
-		baseBlockIDs   []string
-		baseOutputSize int64
+		baseBlockIDsLock sync.Mutex
+		baseBlockIDs     []string
+		baseOutputSize   int64
 	)
 	eg.Go(func() error {
 		url, offset, size, err := baseBlobProvider.GetOutputBlockURL(ctx)
@@ -97,6 +98,8 @@ func (u *Uploader) setupBase(ctx context.Context, baseBlobProvider BaseBlobProvi
 					return fmt.Errorf("upload block from URL: %w", err)
 				}
 
+				baseBlockIDsLock.Lock()
+				defer baseBlockIDsLock.Unlock()
 				baseBlockIDs = append(baseBlockIDs, baseBlockID)
 
 				return nil

--- a/internal/backend/blob/upload.go
+++ b/internal/backend/blob/upload.go
@@ -73,9 +73,8 @@ func (u *Uploader) setupBase(ctx context.Context, baseBlobProvider BaseBlobProvi
 	eg, ctx := errgroup.WithContext(ctx)
 
 	var (
-		baseBlockIDsLock sync.Mutex
-		baseBlockIDs     []string
-		baseOutputSize   int64
+		baseBlockIDs   []string
+		baseOutputSize int64
 	)
 	eg.Go(func() error {
 		url, offset, size, err := baseBlobProvider.GetOutputBlockURL(ctx)
@@ -90,6 +89,7 @@ func (u *Uploader) setupBase(ctx context.Context, baseBlobProvider BaseBlobProvi
 			if err != nil {
 				return fmt.Errorf("generate block ID: %w", err)
 			}
+			baseBlockIDs = append(baseBlockIDs, baseBlockID)
 
 			chunkUploadSize := min(maxUploadChunkSize, size-i)
 			uploadSize = chunkUploadSize
@@ -98,10 +98,6 @@ func (u *Uploader) setupBase(ctx context.Context, baseBlobProvider BaseBlobProvi
 				if err != nil {
 					return fmt.Errorf("upload block from URL: %w", err)
 				}
-
-				baseBlockIDsLock.Lock()
-				defer baseBlockIDsLock.Unlock()
-				baseBlockIDs = append(baseBlockIDs, baseBlockID)
 
 				return nil
 			})

--- a/internal/backend/blob/upload.go
+++ b/internal/backend/blob/upload.go
@@ -40,7 +40,7 @@ type BaseBlobProvider interface {
 	GetOutputBlockURL(ctx context.Context) (url string, offset, size int64, err error)
 }
 
-type waitBaseFunc func() (baseBlockID string, baseOutputSize int64, baseOutputs []*v1.ActionsOutput, err error)
+type waitBaseFunc func() (baseBlockIDs []string, baseOutputSize int64, baseOutputs []*v1.ActionsOutput, err error)
 
 func NewUploader(ctx context.Context, logger log.Logger, client UploadClient, baseBlobProvider BaseBlobProvider) *Uploader {
 	uploader := &Uploader{
@@ -61,35 +61,46 @@ func (u *Uploader) generateBlockID() (string, error) {
 	return base64.StdEncoding.EncodeToString(buf[:]), nil
 }
 
+const maxUploadChunkSize = 4 * (1 << 20)
+
 func (u *Uploader) setupBase(ctx context.Context, baseBlobProvider BaseBlobProvider) waitBaseFunc {
 	if baseBlobProvider == nil {
-		return func() (string, int64, []*v1.ActionsOutput, error) {
-			return "", 0, nil, nil
+		return func() ([]string, int64, []*v1.ActionsOutput, error) {
+			return nil, 0, nil, nil
 		}
 	}
 
 	eg, ctx := errgroup.WithContext(ctx)
 
 	var (
-		baseBlockID    string
+		baseBlockIDs   []string
 		baseOutputSize int64
 	)
 	eg.Go(func() error {
-		var err error
-		baseBlockID, err = u.generateBlockID()
-		if err != nil {
-			return fmt.Errorf("generate block ID: %w", err)
-		}
-
 		url, offset, size, err := baseBlobProvider.GetOutputBlockURL(ctx)
 		if err != nil {
 			return fmt.Errorf("get output block URL: %w", err)
 		}
 		baseOutputSize = size
 
-		err = u.client.UploadBlockFromURL(ctx, baseBlockID, url, offset, size)
-		if err != nil {
-			return fmt.Errorf("upload block from URL: %w", err)
+		var uploadSize int64
+		for i := int64(0); i < size; i += uploadSize {
+			eg.Go(func() error {
+				baseBlockID, err := u.generateBlockID()
+				if err != nil {
+					return fmt.Errorf("generate block ID: %w", err)
+				}
+
+				uploadSize = min(maxUploadChunkSize, size-i)
+				err = u.client.UploadBlockFromURL(ctx, baseBlockID, url, offset+i, uploadSize)
+				if err != nil {
+					return fmt.Errorf("upload block from URL: %w", err)
+				}
+
+				baseBlockIDs = append(baseBlockIDs, baseBlockID)
+
+				return nil
+			})
 		}
 
 		return nil
@@ -106,13 +117,13 @@ func (u *Uploader) setupBase(ctx context.Context, baseBlobProvider BaseBlobProvi
 		return nil
 	})
 
-	return func() (string, int64, []*v1.ActionsOutput, error) {
+	return func() ([]string, int64, []*v1.ActionsOutput, error) {
 		if err := eg.Wait(); err != nil {
-			return "", 0, nil, err
+			return nil, 0, nil, err
 		}
 		u.logger.Debugf("base output size=%d", baseOutputSize)
 
-		return baseBlockID, baseOutputSize, baseOutputs, nil
+		return baseBlockIDs, baseOutputSize, baseOutputs, nil
 	}
 }
 
@@ -218,9 +229,12 @@ func (u *Uploader) createHeader(entries map[string]*v1.IndexEntry, outputs []*v1
 }
 
 func (u *Uploader) Commit(ctx context.Context, entries map[string]*v1.IndexEntry) (int64, error) {
-	baseBlockID, baseOutputSize, baseOutputs, err := u.waitBaseFunc()
+	baseBlockIDs, baseOutputSize, baseOutputs, err := u.waitBaseFunc()
 	if err != nil {
-		return 0, fmt.Errorf("wait base: %w", err)
+		u.logger.Warnf("failed to upload base: %v", err)
+		baseBlockIDs = nil
+		baseOutputSize = 0
+		baseOutputs = []*v1.ActionsOutput{}
 	}
 
 	newOutputIDs, outputs, outputSize := u.constructOutputs(baseOutputSize, baseOutputs)
@@ -242,9 +256,7 @@ func (u *Uploader) Commit(ctx context.Context, entries map[string]*v1.IndexEntry
 
 	blockIDs := make([]string, 0, len(newOutputIDs)+2)
 	blockIDs = append(blockIDs, headerBlockID)
-	if baseBlockID != "" {
-		blockIDs = append(blockIDs, baseBlockID)
-	}
+	blockIDs = append(blockIDs, baseBlockIDs...)
 	blockIDs = append(blockIDs, newOutputIDs...)
 	err = u.client.Commit(ctx, blockIDs)
 	if err != nil {

--- a/internal/backend/blob/upload_test.go
+++ b/internal/backend/blob/upload_test.go
@@ -280,7 +280,7 @@ func TestNewUploader(t *testing.T) {
 				t.Fatal("uploader is nil")
 			}
 
-			blockID, size, outputs, err := uploader.waitBaseFunc()
+			baseBlockIDs, size, outputs, err := uploader.waitBaseFunc()
 			if tt.expectError {
 				if err == nil {
 					t.Error("expected error, got nil")
@@ -293,8 +293,11 @@ func TestNewUploader(t *testing.T) {
 				return
 			}
 
-			if tt.wantBlockIDEmpty && blockID != "" {
-				t.Errorf("blockID should be empty, got %s", blockID)
+			if tt.wantBlockIDEmpty && len(baseBlockIDs) > 0 {
+				t.Errorf("baseBlockIDs should be empty, got %v", baseBlockIDs)
+			}
+			if !tt.wantBlockIDEmpty && len(baseBlockIDs) == 0 {
+				t.Error("baseBlockIDs should not be empty")
 			}
 			if diff := cmp.Diff(tt.wantSize, size); diff != "" {
 				t.Errorf("size mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
Existing output was uploaded using [put-block-from-url](https://docs.microsoft.com/en-us/rest/api/storageservices/put-block-from-url) in Azure blob storage. upload.
However, the latency was about 5~7s due to the fact that the request was made without splitting the data, causing the speed to drop.
Therefore, it was modified to split and upload in parallel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the upload experience by enabling concurrent processing of multiple file segments. This update improves performance and reliability during uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->