### PR TITLE
Switch benchmark target repository from traPtitech/traQ to microsoft/typescript-go

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: traPtitech/traQ
-          ref: v3.22.0
+          repository: microsoft/typescript-go
+          ref: main
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
@@ -68,8 +68,8 @@ jobs:
             console.log("Clear completed")
       - uses: actions/checkout@v4
         with:
-          repository: traPtitech/traQ
-          ref: v3.22.0
+          repository: microsoft/typescript-go
+          ref: main
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
@@ -103,8 +103,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: traPtitech/traQ
-          ref: v3.22.0
+          repository: microsoft/typescript-go
+          ref: main
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
@@ -138,8 +138,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: traPtitech/traQ
-          ref: v3.22.0
+          repository: microsoft/typescript-go
+          ref: main
           fetch-depth: 0
       - name: Clear cache
         uses: actions/github-script@v7
@@ -196,8 +196,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: traPtitech/traQ
-          ref: v3.22.0
+          repository: microsoft/typescript-go
+          ref: main
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/benchmark.yaml` file to update the repository and reference used in several steps. The most important changes are as follows:

Repository and reference updates:

* Updated the repository from `traPtitech/traQ` to `microsoft/typescript-go` and changed the reference from `v3.22.0` to `main` in multiple steps. (.github/workflows/benchmark.yaml) [[1]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L23-R24) [[2]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L71-R72) [[3]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L106-R107) [[4]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L141-R142) [[5]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L199-R200)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automation workflows by changing repository references to streamline internal processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->