### PR TITLE
Update benchmark.yaml to build the tsgo command instead of traQ

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -86,7 +86,7 @@ jobs:
         with:
           version: ${{ github.event.inputs.gocica-version }}
       - run: go mod download
-      - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
+      - run: time go build ./cmd/tsgo
         env:
           CGO_ENABLED: 0
   cache_gocica_github:
@@ -121,7 +121,7 @@ jobs:
         with:
           version: ${{ github.event.inputs.gocica-version }}
       - run: go mod download
-      - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
+      - run: time go build ./cmd/tsgo
         env:
           CGO_ENABLED: 0
   no_cache_default:
@@ -179,7 +179,7 @@ jobs:
             go-build-${{ runner.os }}-${{ github.ref }}-
             go-build-${{ runner.os }}-
       - run: go mod download
-      - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
+      - run: time go build ./cmd/tsgo
         env:
           CGO_ENABLED: 0
   cache_default:
@@ -218,6 +218,6 @@ jobs:
             go-build-${{ runner.os }}-${{ github.ref }}-
             go-build-${{ runner.os }}-
       - run: go mod download
-      - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
+      - run: time go build ./cmd/tsgo
         env:
           CGO_ENABLED: 0


### PR DESCRIPTION
This pull request includes changes to the `jobs:` section in the `.github/workflows/benchmark.yaml` file, specifically modifying the build command used in various steps. The changes replace the previous build command with a new one targeting a different directory and command.

Changes in `.github/workflows/benchmark.yaml`:

* Replaced the build command `time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"` with `time go build ./cmd/tsgo` in multiple steps. [[1]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L89-R89) [[2]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L124-R124) [[3]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L182-R182) [[4]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L221-R221)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the internal build pipeline to compile a new application target while maintaining static linking.
	- Adjusted several build steps for improved consistency within the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->