### PR TITLE
Update benchmark.yaml to switch repository from tsgo to tailscale

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: microsoft/typescript-go
-          ref: main
+          repository: tailscale/tailscale
+          ref: v1.80.3
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
@@ -68,8 +68,8 @@ jobs:
             console.log("Clear completed")
       - uses: actions/checkout@v4
         with:
-          repository: microsoft/typescript-go
-          ref: main
+          repository: tailscale/tailscale
+          ref: v1.80.3
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
@@ -86,7 +86,7 @@ jobs:
         with:
           version: ${{ github.event.inputs.gocica-version }}
       - run: go mod download
-      - run: time go build ./cmd/tsgo
+      - run: time go build ./cmd/...
         env:
           CGO_ENABLED: 0
   cache_gocica_github:
@@ -103,8 +103,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: microsoft/typescript-go
-          ref: main
+          repository: tailscale/tailscale
+          ref: v1.80.3
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
@@ -121,7 +121,7 @@ jobs:
         with:
           version: ${{ github.event.inputs.gocica-version }}
       - run: go mod download
-      - run: time go build ./cmd/tsgo
+      - run: time go build ./cmd/...
         env:
           CGO_ENABLED: 0
   no_cache_default:
@@ -138,8 +138,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: microsoft/typescript-go
-          ref: main
+          repository: tailscale/tailscale
+          ref: v1.80.3
           fetch-depth: 0
       - name: Clear cache
         uses: actions/github-script@v7
@@ -179,7 +179,7 @@ jobs:
             go-build-${{ runner.os }}-${{ github.ref }}-
             go-build-${{ runner.os }}-
       - run: go mod download
-      - run: time go build ./cmd/tsgo
+      - run: time go build ./cmd/...
         env:
           CGO_ENABLED: 0
   cache_default:
@@ -196,8 +196,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: microsoft/typescript-go
-          ref: main
+          repository: tailscale/tailscale
+          ref: v1.80.3
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
@@ -218,6 +218,6 @@ jobs:
             go-build-${{ runner.os }}-${{ github.ref }}-
             go-build-${{ runner.os }}-
       - run: go mod download
-      - run: time go build ./cmd/tsgo
+      - run: time go build ./cmd/...
         env:
           CGO_ENABLED: 0


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/benchmark.yaml` file to update repository references and simplify the build command.

Repository updates:

* Changed the repository from `microsoft/typescript-go` to `tailscale/tailscale` and updated the reference from `main` to `v1.80.3` in multiple steps. [[1]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L23-R24) [[2]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L71-R72) [[3]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L106-R107) [[4]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L141-R142) [[5]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L199-R200)

Build command simplification:

* Simplified the `go build` command from `time go build ./cmd/tsgo` to `time go build ./cmd/...` in multiple steps. [[1]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L89-R89) [[2]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L124-R124) [[3]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L182-R182) [[4]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L221-R221)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the automation workflow to reference a stable external dependency version and broadened the build process for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->