### PR TITLE
build with internal linking and trimpath

### DIFF
--- a/.github/workflows/pullrequest-ci.yaml
+++ b/.github/workflows/pullrequest-ci.yaml
@@ -96,7 +96,7 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v3
       - run: go mod download
       - run: mkdir ./tmp
-      - run: time go build -trimpath -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local -linkmode=internal"
+      - run: time go build -trimpath -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local -linkmode=internal all=-buildid="
         env:
           CGO_ENABLED: 0
           GOCACHEPROG: "./${{ env.APP_NAME }} --dev.cpu-prof=./tmp/cpu.prof --dev.fg-prof=./tmp/fgprof.prof --dev.mem-prof=./tmp/mem.prof --dev.metrics=./tmp/metrics.csv"

--- a/.github/workflows/pullrequest-ci.yaml
+++ b/.github/workflows/pullrequest-ci.yaml
@@ -96,7 +96,7 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v3
       - run: go mod download
       - run: mkdir ./tmp
-      - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
+      - run: time go build -trimpath -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local -linkmode=internal"
         env:
           CGO_ENABLED: 0
           GOCACHEPROG: "./${{ env.APP_NAME }} --dev.cpu-prof=./tmp/cpu.prof --dev.fg-prof=./tmp/fgprof.prof --dev.mem-prof=./tmp/mem.prof --dev.metrics=./tmp/metrics.csv"

--- a/.github/workflows/pullrequest-ci.yaml
+++ b/.github/workflows/pullrequest-ci.yaml
@@ -99,7 +99,7 @@ jobs:
       - run: time go build -trimpath -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local -linkmode=internal -buildid=none"
         env:
           CGO_ENABLED: 0
-          GOGCCFLAGS: ""
+          GOGCCFLAGS: "-fPIC -m64 -pthread -Wl,--no-gc-sections -fmessage-length=0 -gno-record-gcc-switches"
           GOCACHEPROG: "./${{ env.APP_NAME }} --dev.cpu-prof=./tmp/cpu.prof --dev.fg-prof=./tmp/fgprof.prof --dev.mem-prof=./tmp/mem.prof --dev.metrics=./tmp/metrics.csv"
       - name: Upload assets
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pullrequest-ci.yaml
+++ b/.github/workflows/pullrequest-ci.yaml
@@ -96,7 +96,7 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v3
       - run: go mod download
       - run: mkdir ./tmp
-      - run: time go build -trimpath -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local -linkmode=internal all=-buildid="
+      - run: time go build -trimpath -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local -linkmode=internal -buildid=none"
         env:
           CGO_ENABLED: 0
           GOCACHEPROG: "./${{ env.APP_NAME }} --dev.cpu-prof=./tmp/cpu.prof --dev.fg-prof=./tmp/fgprof.prof --dev.mem-prof=./tmp/mem.prof --dev.metrics=./tmp/metrics.csv"

--- a/.github/workflows/pullrequest-ci.yaml
+++ b/.github/workflows/pullrequest-ci.yaml
@@ -99,6 +99,7 @@ jobs:
       - run: time go build -trimpath -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local -linkmode=internal -buildid=none"
         env:
           CGO_ENABLED: 0
+          GOGCCFLAGS: ""
           GOCACHEPROG: "./${{ env.APP_NAME }} --dev.cpu-prof=./tmp/cpu.prof --dev.fg-prof=./tmp/fgprof.prof --dev.mem-prof=./tmp/mem.prof --dev.metrics=./tmp/metrics.csv"
       - name: Upload assets
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request includes a significant change to the build process in the CI workflow. The most important change is the modification of the `go build` command to improve the build process.

Build process improvement:

* [`.github/workflows/pullrequest-ci.yaml`](diffhunk://#diff-1a4780cb3787799e362b101f62b6658ad15998550cf30712a97dc22bfe7ff16fL99-R99): Updated the `go build` command to include the `-trimpath` flag and changed the `-linkmode` to `internal` to enhance the build process.