### PR TITLE
buildvcs false

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -14,7 +14,7 @@ env:
   TARGET_REPO: fujiwara/awslim
   TARGET_REF: v0.4.0
   PRE_BUILD_CMD: cp all-services.yaml gen.yaml && go generate ./cmd/awslim-gen
-  BUILD_CMD: go build ./cmd/awslim/
+  BUILD_CMD: go build -buildvcs=false ./cmd/awslim/
 
 jobs:
   setup_modcache:

--- a/.github/workflows/pullrequest-ci.yaml
+++ b/.github/workflows/pullrequest-ci.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Expose GitHub Actions runtime environment variables
         uses: crazy-max/ghaction-github-runtime@v3
       - name: Build standard library
-        run: time go install std
+        run: time go install -buildvcs=false std
         env:
           GOCACHEPROG: "./${{ env.APP_NAME }}"
   traq_build:
@@ -96,7 +96,7 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v3
       - run: go mod download
       - run: mkdir ./tmp
-      - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
+      - run: time go build -o traQ -buildvcs=false -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
         env:
           CGO_ENABLED: 0
           GOCACHEPROG: "./${{ env.APP_NAME }} --dev.cpu-prof=./tmp/cpu.prof --dev.fg-prof=./tmp/fgprof.prof --dev.mem-prof=./tmp/mem.prof --dev.metrics=./tmp/metrics.csv"


### PR DESCRIPTION
This pull request updates several `go build` and `go install` commands in GitHub Actions workflows to include the `-buildvcs=false` flag. This change disables version control information embedding during builds, likely to improve build performance or address compatibility issues.

### Updates to GitHub Actions workflows:

* [`.github/workflows/benchmark.yaml`](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L17-R17): Modified the `BUILD_CMD` in the `env:` section to include the `-buildvcs=false` flag in the `go build` command.

* `.github/workflows/pullrequest-ci.yaml`:
  - Updated the `go install` command in the "Build standard library" step to include the `-buildvcs=false` flag.
  - Updated the `go build` command in the "traq_build" job to include the `-buildvcs=false` flag.