### PR TITLE
set GOMAXPROCS

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/alecthomas/kong"
 	"github.com/mazrean/gocica/internal"
@@ -32,7 +33,8 @@ var CLI struct {
 		Ref      string `kong:"help='GitHub base ref of the workflow or the target branch of the pull request',env='GOCICA_GITHUB_REF,GITHUB_REF'"`
 		Sha      string `kong:"help='GitHub SHA of the commit',env='GOCICA_GITHUB_SHA,GITHUB_SHA'"`
 	} `kong:"optional,group='github',embed,prefix='github.'"`
-	Dev DevFlag `kong:"group='dev',embed,prefix='dev.'"`
+	Dev      DevFlag `kong:"group='dev',embed,prefix='dev.'"`
+	MaxProcs int     `kong:"help='Maximum number of CPUs to use',env='GOCICA_GOMAXPROCS',default='1'"`
 }
 
 // loadConfig loads and parses configuration from command line arguments
@@ -108,6 +110,9 @@ func main() {
 
 	// Initialize default logger with info level
 	logger := log.DefaultLogger
+
+	// Set GOMAXPROCS
+	runtime.GOMAXPROCS(CLI.MaxProcs)
 
 	// Start profiling. Enable profiling only in development mode.
 	if err := CLI.Dev.StartProfiling(); err != nil {


### PR DESCRIPTION
This pull request introduces a new feature to control the maximum number of CPUs used by the application through a command-line argument and environment variable. It also includes minor changes to support this feature.

### New feature: CPU usage control

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R37): Added a new `MaxProcs` field to the `CLI` struct, allowing users to specify the maximum number of CPUs to use via the `--max-procs` command-line argument or the `GOCICA_GOMAXPROCS` environment variable. The default is set to `1`.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R7): Imported the `runtime` package to enable setting the maximum number of CPUs.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R114-R116): Updated the `main` function to use `runtime.GOMAXPROCS` to apply the `MaxProcs` value specified by the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configuration option to control the maximum number of CPUs used by the application, with support for setting via environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->