### PR TITLE
remove max proc limit

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/alecthomas/kong"
 	"github.com/mazrean/gocica/internal"
@@ -33,8 +32,7 @@ var CLI struct {
 		Ref      string `kong:"help='GitHub base ref of the workflow or the target branch of the pull request',env='GOCICA_GITHUB_REF,GITHUB_REF'"`
 		Sha      string `kong:"help='GitHub SHA of the commit',env='GOCICA_GITHUB_SHA,GITHUB_SHA'"`
 	} `kong:"optional,group='github',embed,prefix='github.'"`
-	Dev      DevFlag `kong:"group='dev',embed,prefix='dev.'"`
-	MaxProcs int     `kong:"help='Maximum number of CPUs to use',env='GOCICA_GOMAXPROCS',default='1'"`
+	Dev DevFlag `kong:"group='dev',embed,prefix='dev.'"`
 }
 
 // loadConfig loads and parses configuration from command line arguments
@@ -110,9 +108,6 @@ func main() {
 
 	// Initialize default logger with info level
 	logger := log.DefaultLogger
-
-	// Set GOMAXPROCS
-	runtime.GOMAXPROCS(CLI.MaxProcs)
 
 	// Start profiling. Enable profiling only in development mode.
 	if err := CLI.Dev.StartProfiling(); err != nil {


### PR DESCRIPTION
This pull request simplifies the `main.go` file by removing unused imports, eliminating a configuration option for setting the maximum number of CPUs, and cleaning up related logic. These changes streamline the codebase and reduce unnecessary complexity.

### Codebase Simplification:

* Removed the unused `runtime` package import from the `import` block. (`main.go`, [main.goL7](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L7))
* Eliminated the `MaxProcs` field from the `CLI` struct, which was used to configure the maximum number of CPUs. (`main.go`, [main.goL37](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L37))
* Removed the logic for setting `GOMAXPROCS` in the `main` function, as it is no longer configurable through the CLI. (`main.go`, [main.goL114-L116](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L114-L116))