### PR TITLE
add metrics

### DIFF
--- a/.github/workflows/pullrequest-ci.yaml
+++ b/.github/workflows/pullrequest-ci.yaml
@@ -99,7 +99,7 @@ jobs:
       - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
         env:
           CGO_ENABLED: 0
-          GOCACHEPROG: "./${{ env.APP_NAME }} --dev.cpu-prof=./tmp/cpu.prof --dev.fg-prof=./tmp/fgprof.prof --dev.mem-prof=./tmp/mem.prof --dev.metrics=./tmp/metrics.csv"
+          GOCACHEPROG: "./${{ env.APP_NAME }} --dev.cpu-prof=./tmp/cpu.prof --dev.fg-prof=./tmp/fgprof.prof --dev.mem-prof=./tmp/mem.prof --dev.metrics=./tmp/metrics.csv --dev.mutex-prof=./tmp/mutex.prof"
       - name: Upload assets
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pullrequest-ci.yaml
+++ b/.github/workflows/pullrequest-ci.yaml
@@ -99,7 +99,7 @@ jobs:
       - run: time go build -o traQ -ldflags "-s -w -X main.version=Dev -X main.revision=Local"
         env:
           CGO_ENABLED: 0
-          GOCACHEPROG: "./${{ env.APP_NAME }} --dev.cpu-prof=./tmp/cpu.prof --dev.fg-prof=./tmp/fgprof.prof --dev.mem-prof=./tmp/mem.prof --dev.metrics=./tmp/metrics.csv --dev.mutex-prof=./tmp/mutex.prof"
+          GOCACHEPROG: "./${{ env.APP_NAME }} --dev.cpu-prof=./tmp/cpu.prof --dev.fg-prof=./tmp/fgprof.prof --dev.mem-prof=./tmp/mem.prof --dev.metrics=./tmp/metrics.csv --dev.mutex-prof=./tmp/mutex.prof --dev.block-prof=./tmp/block.prof"
       - name: Upload assets
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This pull request introduces metrics tracking to the backend system in `internal/backend/backend.go`. The changes add gauges for monitoring request counts, request durations, and cache hit/miss rates, enabling better observability of backend operations.

### Metrics Integration:

* **Import of Metrics Library**: Added `github.com/mazrean/gocica/internal/metrics` to enable the use of metrics gauges. (`internal/backend/backend.go`, [internal/backend/backend.goR11](diffhunk://#diff-b1dc3aac3a118369fbdb1a9b69c52028707121aadceea4dc1246e62e94f88929R11))
* **Gauge Definitions**: Introduced three gauges (`requestGauge`, `durationGauge`, and `cacheHitGauge`) for tracking backend requests, durations, and cache hit/miss rates. (`internal/backend/backend.go`, [internal/backend/backend.goR49-R54](diffhunk://#diff-b1dc3aac3a118369fbdb1a9b69c52028707121aadceea4dc1246e62e94f88929R49-R54))

### Backend Functionality Updates:

* **`Get` Method Enhancements**: Integrated metrics tracking into the `Get` method to measure request counts, cache hit/miss rates, and execution durations. (`internal/backend/backend.go`, [internal/backend/backend.goR106-R147](diffhunk://#diff-b1dc3aac3a118369fbdb1a9b69c52028707121aadceea4dc1246e62e94f88929R106-R147))
* **`Put` Method Enhancements**: Added metrics tracking for request counts in the `Put` method. (`internal/backend/backend.go`, [internal/backend/backend.goR215-R216](diffhunk://#diff-b1dc3aac3a118369fbdb1a9b69c52028707121aadceea4dc1246e62e94f88929R215-R216))