### PR TITLE
fix benchmark

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         id: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
       max-parallel: 1
+    needs: [cache_default]
     steps:
       - name: Clear cache
         uses: actions/github-script@v7
@@ -33,6 +34,20 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               key: "gocica-cache-"
+            })
+            for (const cache of caches.data.actions_caches) {
+              console.log(cache)
+              github.rest.actions.deleteActionsCacheById({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                cache_id: cache.id,
+              })
+            }
+            console.log("About to clear setup-go cache")
+            const caches = await github.rest.actions.getActionsCacheList({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              key: "setup-go-"
             })
             for (const cache of caches.data.actions_caches) {
               console.log(cache)


### PR DESCRIPTION
This pull request updates the `.github/workflows/benchmark.yaml` file to improve cache handling in the benchmark workflow. The changes introduce a dependency on the `cache_default` job and add logic to clear specific caches related to `setup-go`.

### Workflow improvements:

* [`.github/workflows/benchmark.yaml`](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R26): Added `needs: [cache_default]` to ensure the benchmark job depends on the completion of the `cache_default` job.

### Cache management enhancements:

* [`.github/workflows/benchmark.yaml`](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R46-R59): Added logic to retrieve and delete caches with keys prefixed by `setup-go-`, including logging details about the caches being cleared.